### PR TITLE
[FEAT/#11] STT 구현 

### DIFF
--- a/app/api/answer.py
+++ b/app/api/answer.py
@@ -1,0 +1,85 @@
+from fastapi import APIRouter, Depends, UploadFile, File, Form, HTTPException
+
+from app.schemas.responses import AudioAnswerResponse
+from app.services.answer import get_answer_service, AnswerService
+from app.services.question import get_question_service, QuestionService
+from app.core.constants import ALLOWED_AUDIO_TYPES, MAX_AUDIO_FILE_SIZE, ErrorMessages
+from app.utils.common import format_message
+
+router = APIRouter(prefix="/answer", tags=["answer"])
+
+@router.get("/questions")
+async def get_questions(
+    question_service: QuestionService = Depends(get_question_service)
+):
+    """전체 질문 목록 조회"""
+    return {
+        "total_questions": question_service.get_total_questions(),
+        "questions": question_service.get_all_questions()
+    }
+
+@router.get("/questions/{question_number}")
+async def get_question(
+    question_number: int,
+    question_service: QuestionService = Depends(get_question_service)
+):
+    """특정 질문 조회"""
+    if not question_service.is_valid_question_number(question_number):
+        raise HTTPException(
+            status_code=404,
+            detail=format_message(ErrorMessages.QUESTION_NOT_FOUND, question_number=question_number)
+        )
+    
+    return {
+        "question_number": question_number,
+        "question_text": question_service.get_question_text(question_number)
+    }
+
+@router.post("/audio", response_model=AudioAnswerResponse)
+async def upload_audio_answer(
+    audio_file: UploadFile = File(..., description="오디오 파일 (wav, mp3, m4a, webm, ogg 등)"),
+    question_number: int = Form(..., description="질문 번호 (1-3)"),
+    user_id: str = Form(..., description="사용자 ID"),
+    answer_service: AnswerService = Depends(get_answer_service)
+):
+    """오디오 파일로 답변 제출 (한국 시간 기준)"""
+    try:
+        _validate_audio_file(audio_file)
+        
+        result = await answer_service.process_audio_answer(
+            audio_file=audio_file,
+            question_number=question_number,
+            user_id=user_id
+        )
+        
+        return AudioAnswerResponse(**result)
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=format_message(ErrorMessages.AUDIO_ANSWER_PROCESSING_ERROR, error=str(e))
+        )
+
+def _validate_audio_file(audio_file: UploadFile):
+    """오디오 파일 유효성 검사"""
+    if audio_file.content_type not in ALLOWED_AUDIO_TYPES:
+        raise HTTPException(
+            status_code=400, 
+            detail=format_message(
+                ErrorMessages.UNSUPPORTED_AUDIO_FORMAT, 
+                formats=', '.join(ALLOWED_AUDIO_TYPES)
+            )
+        )
+    
+    audio_file.file.seek(0, 2)
+    file_size = audio_file.file.tell()
+    audio_file.file.seek(0)
+    
+    if file_size > MAX_AUDIO_FILE_SIZE:
+        max_size_mb = MAX_AUDIO_FILE_SIZE // (1024 * 1024)
+        raise HTTPException(
+            status_code=400,
+            detail=format_message(ErrorMessages.FILE_SIZE_EXCEEDED, max_size=max_size_mb)
+        )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -18,6 +18,11 @@ class Settings:
     MONGODB_DATABASE: str = os.getenv("MONGODB_DATABASE", "database")
     
     GEMINI_API_KEY: str = os.getenv("GEMINI_API_KEY", "")
+    OPENAI_API_KEY: str = os.getenv("OPENAI_API_KEY", "")
+    
+    GCP_BUCKET_NAME: str = os.getenv("GCP_BUCKET_NAME", "moa-audio-storage")
+    GCP_PROJECT_ID: str = os.getenv("GCP_PROJECT_ID", "")
+    GOOGLE_APPLICATION_CREDENTIALS: str = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")
     
     ALLOWED_ORIGINS: list = [
         "http://localhost:3000",

--- a/app/core/constants.py
+++ b/app/core/constants.py
@@ -1,0 +1,97 @@
+"""애플리케이션 상수 정의"""
+
+# 질문 관련 상수
+MAX_QUESTION_NUMBER = 3
+MIN_QUESTION_NUMBER = 1
+FINAL_QUESTION_NUMBER = 3
+
+# 질문 내용
+QUESTIONS = {
+    1: "오늘 부양하면서 어떤 순간이 가장 기억에 남나요?",
+    2: "지금 이 순간 마음속에서 가장 큰 감정은 무엇인가요?",
+    3: "오늘 나 자신에게 해주고 싶은 말이 있다면?"
+}
+
+# 오디오 파일 관련 상수
+MAX_AUDIO_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+ALLOWED_AUDIO_TYPES = [
+    "audio/wav",
+    "audio/mpeg",
+    "audio/mp4",
+    "audio/m4a",
+    "audio/webm",
+    "audio/ogg",
+    "audio/x-wav",
+    "audio/x-m4a",
+    "audio/aac",
+    "audio/flac",
+    "audio/3gpp",
+]
+
+# AI 관련 상수
+DEFAULT_AI_SENTIMENT = "neutral"
+DEFAULT_AI_SCORE = 0.0
+STT_MODEL = "whisper-1"
+STT_LANGUAGE = "ko"
+STT_TEMPERATURE = 0
+
+# 메시지 상수
+class Messages:
+    AUDIO_UPLOAD_SUCCESS = "질문 {question_number} 오디오가 저장되었습니다."
+    ALL_ANSWERS_COMPLETE = "모든 답변 처리가 완료되었습니다."
+    ONBOARDING_SUCCESS = "온보딩이 성공적으로 완료되었습니다."
+    ONBOARDING_COMPLETE = "온보딩 완료"
+    ONBOARDING_INCOMPLETE = "온보딩 미완료"
+    DEFAULT_COMFORT_MESSAGE = "답변들이 저장되고 있습니다."
+    
+    STT_START = "🎤 전체 오디오 STT 처리 시작..."
+    STT_COMPLETE = "✅ 전체 오디오 STT 처리 완료"
+    STT_NO_FILES = "⚠️ 처리할 오디오 파일이 없습니다."
+    STT_PROCESSING = "📝 {count}개의 오디오 파일 처리 중..."
+    STT_QUESTION_SUCCESS = "✅ 질문 {question_num} STT 완료: {text}..."
+    STT_QUESTION_FAILED = "❌ 질문 {question_num} STT 실패: {error}"
+    STT_FAILED = "❌ 전체 오디오 STT 처리 실패: {error}"
+    
+    AUDIO_URI_SAVE_SUCCESS = "✅ 질문 {question_number} 오디오 URI 저장 완료: {audio_uri}"
+    AUDIO_URI_SAVE_FAILED = "❌ 오디오 URI 저장 실패: {error}"
+    
+    USER_CREATED = "새 사용자 생성: {user_id}"
+    CONVERSATION_CREATED = "새 Conversation 생성: {user_id} - {date} (한국 시간)"
+    
+    AUDIO_PROCESSING_FAILED = "❌ 오디오 답변 처리 실패: {error}"
+
+# 에러 메시지 상수
+class ErrorMessages:
+    INVALID_QUESTION_NUMBER = "유효하지 않은 질문 번호입니다. (1-{max_questions})"
+    QUESTION_NOT_FOUND = "질문 번호 {question_number}를 찾을 수 없습니다."
+    UNSUPPORTED_AUDIO_FORMAT = "지원하지 않는 오디오 형식입니다. 지원 형식: {formats}"
+    FILE_SIZE_EXCEEDED = "파일 크기가 {max_size}MB를 초과합니다."
+    USER_NOT_FOUND = "사용자를 찾을 수 없습니다."
+    AUDIO_FILE_NOT_FOUND = "오디오 파일을 찾을 수 없습니다."
+    STT_TIMEOUT = "음성 변환 시간이 초과되었습니다."
+    INVALID_API_KEY = "OpenAI API 키가 유효하지 않습니다."
+    INVALID_GCS_URI = "잘못된 GCS URI 형식: {uri}"
+    STT_CONVERSION_FAILED = "음성 변환 실패: {error}"
+    ONBOARDING_PROCESSING_ERROR = "온보딩 처리 중 오류가 발생했습니다: {error}"
+    ONBOARDING_STATUS_ERROR = "온보딩 상태 조회 중 오류가 발생했습니다: {error}"
+    HISTORY_QUERY_ERROR = "기록 조회 중 오류가 발생했습니다: {error}"
+    AUDIO_ANSWER_PROCESSING_ERROR = "오디오 답변 처리 중 오류가 발생했습니다: {error}"
+    ENUM_VALIDATION_MISSING = "데이터 검증 실패: {field_name}이(가) 설정되지 않았습니다."
+    ENUM_VALIDATION_INVALID = "데이터 검증 실패: {field_name}이(가) 올바른 Enum 타입이 아닙니다."
+
+# 디폴트 값 상수
+class Defaults:
+    USER_CONVERSATIONS_COUNT = 0
+    USER_ONBOARDED_STATUS = False
+    CONVERSATION_PROCESSED_STATUS = True
+    USER_MESSAGE_EMPTY = ""
+    HISTORY_LIMIT = 10
+    TEXT_PREVIEW_LENGTH = 50
+
+# 파일 형식 상수
+class FileFormats:
+    DATE_FORMAT = "%Y-%m-%d"
+    TEMP_FILE_PREFIX = "audio_"
+    
+# 타임존 상수
+KOREA_TIMEZONE = "Asia/Seoul"

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 
 from app.core.config import settings
 from app.core.database import connect_to_mongo, close_mongo_connection
-from app.api import analysis, users, websocket
+from app.api import analysis, users, websocket, answer
 
 import app.core.logger
 
@@ -34,6 +34,7 @@ def create_app() -> FastAPI:
 
     app.include_router(analysis.router, prefix="/api")
     app.include_router(users.router, prefix="/api")
+    app.include_router(answer.router, prefix="/api")
     app.include_router(websocket.router)
 
     @app.get("/")

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -1,20 +1,28 @@
 from datetime import datetime
+from typing import Optional
 from beanie import Document
 from app.schemas.common import Gender, DementiaStage, FamilyRelationship
+from app.utils.common import get_korea_now
+from app.core.constants import Defaults
 
 class Conversation(Document):
     """대화 기록 모델 - 사용자 메시지와 AI 응답을 하나로 관리"""
     user_id: str
+    conversation_date: str
     
     user_message: str
-    user_timestamp: datetime = datetime.now()
+    user_timestamp: datetime = get_korea_now()
     
-    ai_sentiment: str  # positive, neutral, negative
-    ai_score: float  # -1.0 ~ 1.0
+    ai_sentiment: str
+    ai_score: float
     ai_comfort_message: str
-    ai_timestamp: datetime = datetime.now()
+    ai_timestamp: datetime = get_korea_now()
     
-    is_processed: bool = True  
+    is_processed: bool = Defaults.CONVERSATION_PROCESSED_STATUS
+    
+    audio_uri_1: Optional[str] = None
+    audio_uri_2: Optional[str] = None
+    audio_uri_3: Optional[str] = None
     
     class Settings:
         name = "conversations"
@@ -28,16 +36,15 @@ class User(Document):
     family_relationship: FamilyRelationship
     daily_care_hours: int
     
-    # 부양받는 가족 정보
     family_member_nickname: str
     family_member_birth_year: int
     family_member_gender: Gender
     family_member_dementia_stage: DementiaStage
     
-    created_at: datetime = datetime.now()
-    last_active: datetime = datetime.now()
-    total_conversations: int = 0
-    is_onboarded: bool = False  # 온보딩 완료 여부
+    created_at: datetime = get_korea_now()
+    last_active: datetime = get_korea_now()
+    total_conversations: int = Defaults.USER_CONVERSATIONS_COUNT
+    is_onboarded: bool = Defaults.USER_ONBOARDED_STATUS
     
     class Settings:
         name = "users"

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Optional
 from beanie import Document
+from pydantic import Field
 from app.schemas.common import Gender, DementiaStage, FamilyRelationship
 from app.utils.common import get_korea_now
 from app.core.constants import Defaults
@@ -11,12 +12,12 @@ class Conversation(Document):
     conversation_date: str
     
     user_message: str
-    user_timestamp: datetime = get_korea_now()
+    user_timestamp: datetime = Field(default_factory=get_korea_now)
     
     ai_sentiment: str
     ai_score: float
     ai_comfort_message: str
-    ai_timestamp: datetime = get_korea_now()
+    ai_timestamp: datetime = Field(default_factory=get_korea_now)
     
     is_processed: bool = Defaults.CONVERSATION_PROCESSED_STATUS
     
@@ -41,8 +42,8 @@ class User(Document):
     family_member_gender: Gender
     family_member_dementia_stage: DementiaStage
     
-    created_at: datetime = get_korea_now()
-    last_active: datetime = get_korea_now()
+    created_at: datetime = Field(default_factory=get_korea_now)
+    last_active: datetime = Field(default_factory=get_korea_now)
     total_conversations: int = Defaults.USER_CONVERSATIONS_COUNT
     is_onboarded: bool = Defaults.USER_ONBOARDED_STATUS
     

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -12,14 +12,12 @@ class FamilyMemberInfo(BaseModel):
 
 class CompleteOnboardingRequest(BaseModel):
     """완전한 온보딩 요청 - 사용자 + 가족 정보"""
-    # 사용자 정보 (My Profile Setup)
     user_name: str = Field(..., min_length=1, max_length=50, description="사용자 이름")
     user_birth_year: int = Field(..., ge=1900, le=datetime.now().year, description="사용자 출생년도 (4자리)")
     user_gender: Gender = Field(..., description="사용자 성별")
     family_relationship: FamilyRelationship = Field(..., description="가족과의 관계")
     daily_care_hours: int = Field(..., ge=1, le=24, description="하루 돌봄 시간 (시간)")
     
-    # 가족 정보 (Family Profile Setup)
     family_member: FamilyMemberInfo = Field(..., description="부양해야 할 가족 구성원 정보")
 
 class MessageRequest(BaseModel):
@@ -28,4 +26,3 @@ class MessageRequest(BaseModel):
 
 class WebSocketMessage(BaseModel):
     message: str
-    user_id: Optional[str] = None 

--- a/app/schemas/responses.py
+++ b/app/schemas/responses.py
@@ -30,10 +30,10 @@ class AnalysisResponse(BaseModel):
 class AudioAnswerResponse(BaseModel):
     """오디오 답변 처리 응답"""
     success: bool
-    conversation_id: str = None
+    conversation_id: Optional[str] = None
     question_number: int
-    question_text: str = None
-    message: str = None
+    question_text: Optional[str] = None
+    message: Optional[str] = None
     
     audio_uri_1: Optional[str] = None
     audio_uri_2: Optional[str] = None
@@ -42,7 +42,7 @@ class AudioAnswerResponse(BaseModel):
     user_message: Optional[str] = None
     
     user_id: str
-    error: str = None
+    error: Optional[str] = None
 
 class ConversationItem(BaseModel):
     """대화 기록 아이템"""

--- a/app/schemas/responses.py
+++ b/app/schemas/responses.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 class FamilyMemberResponse(BaseModel):
     """가족 구성원 응답"""
@@ -27,18 +27,39 @@ class AnalysisResponse(BaseModel):
     score: float
     comfort_message: str
 
+class AudioAnswerResponse(BaseModel):
+    """오디오 답변 처리 응답"""
+    success: bool
+    conversation_id: str = None
+    question_number: int
+    question_text: str = None
+    message: str = None
+    
+    audio_uri_1: Optional[str] = None
+    audio_uri_2: Optional[str] = None
+    audio_uri_3: Optional[str] = None
+    
+    user_message: Optional[str] = None
+    
+    user_id: str
+    error: str = None
+
 class ConversationItem(BaseModel):
     """대화 기록 아이템"""
     id: str
+    conversation_date: str
     user_message: str
     user_timestamp: datetime
     ai_sentiment: str
     ai_score: float
     ai_comfort_message: str
     ai_timestamp: datetime
+    audio_uri_1: Optional[str] = None
+    audio_uri_2: Optional[str] = None
+    audio_uri_3: Optional[str] = None
 
 class UserHistoryResponse(BaseModel):
     """사용자 기록 응답"""
     user_id: str
     total_count: int
-    conversations: List[ConversationItem] 
+    conversations: List[ConversationItem]

--- a/app/services/answer.py
+++ b/app/services/answer.py
@@ -92,15 +92,13 @@ class AnswerService:
             )
     
     async def _ensure_user_exists(self, user_id: str) -> User:
-        """사용자가 존재하지 않으면 생성"""
+        """사용자가 존재하는지 확인하고, 없으면 오류 발생"""
         user = await User.find_one(User.user_id == user_id)
         if not user:
-            user = User(
-                user_id=user_id,
-                total_conversations=Defaults.USER_CONVERSATIONS_COUNT
+            raise HTTPException(
+                status_code=404,
+                detail=ErrorMessages.USER_NOT_FOUND
             )
-            await user.save()
-            logger.info(format_message(Messages.USER_CREATED, user_id=user_id))
         return user
     
     async def _find_or_create_conversation(self, user_id: str) -> Conversation:

--- a/app/services/answer.py
+++ b/app/services/answer.py
@@ -156,7 +156,7 @@ class AnswerService:
             for question_num, audio_uri in audio_uris:
                 try:
                     question_text = self.question_service.get_question_text(question_num)
-                    transcribed_text = await self.speech_to_text_service.transcribe_audio(audio_uri)
+                    transcribed_text = self.speech_to_text_service.transcribe_audio(audio_uri)
                     
                     if question_text and transcribed_text:
                         message_parts.extend([

--- a/app/services/answer.py
+++ b/app/services/answer.py
@@ -1,0 +1,215 @@
+from typing import Dict
+from fastapi import UploadFile, HTTPException
+import logging
+
+from app.models.models import Conversation, User
+from app.services.gcp_storage import get_gcp_storage_service
+from app.services.speech_to_text import get_speech_to_text_service
+from app.services.question import get_question_service
+from app.utils.common import (
+    get_korea_now, get_korea_today, format_message, 
+    create_success_response, create_error_response
+)
+from app.core.constants import (
+    FINAL_QUESTION_NUMBER, Messages, ErrorMessages, 
+    Defaults, DEFAULT_AI_SENTIMENT, DEFAULT_AI_SCORE
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AnswerService:
+    """답변 처리 서비스"""
+    
+    def __init__(self):
+        self.gcp_storage_service = get_gcp_storage_service()
+        self.speech_to_text_service = get_speech_to_text_service()
+        self.question_service = get_question_service()
+    
+    async def process_audio_answer(
+        self, 
+        audio_file: UploadFile, 
+        question_number: int, 
+        user_id: str
+    ) -> Dict:
+        """오디오 파일을 처리하여 답변을 저장"""
+        try:
+            if not self.question_service.is_valid_question_number(question_number):
+                raise HTTPException(
+                    status_code=400,
+                    detail=format_message(
+                        ErrorMessages.INVALID_QUESTION_NUMBER,
+                        max_questions=self.question_service.get_total_questions()
+                    )
+                )
+            
+            question_text = self.question_service.get_question_text(question_number)
+            await self._ensure_user_exists(user_id)
+            
+            gcs_uri = await self.gcp_storage_service.upload_audio_file(audio_file, user_id)
+            conversation = await self._find_or_create_conversation(user_id)
+            await self._save_audio_uri(conversation, question_number, gcs_uri)
+            
+            if question_number == FINAL_QUESTION_NUMBER:
+                await self._process_all_audio_to_text(conversation)
+                
+                conversation = await Conversation.find_one(
+                    Conversation.user_id == user_id,
+                    Conversation.conversation_date == get_korea_today()
+                )
+                
+                return create_success_response(
+                    conversation_id=str(conversation.id),
+                    question_number=question_number,
+                    question_text=question_text,
+                    message=Messages.ALL_ANSWERS_COMPLETE,
+                    user_id=user_id,
+                    user_message=conversation.user_message,
+                    audio_uri_1=conversation.audio_uri_1,
+                    audio_uri_2=conversation.audio_uri_2,
+                    audio_uri_3=conversation.audio_uri_3
+                )
+            else:
+                return create_success_response(
+                    conversation_id=str(conversation.id),
+                    question_number=question_number,
+                    question_text=question_text,
+                    message=format_message(Messages.AUDIO_UPLOAD_SUCCESS, question_number=question_number),
+                    user_id=user_id,
+                    audio_uri_1=conversation.audio_uri_1,
+                    audio_uri_2=conversation.audio_uri_2,
+                    audio_uri_3=conversation.audio_uri_3
+                )
+            
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(format_message(Messages.AUDIO_PROCESSING_FAILED, error=e))
+            return create_error_response(
+                error=str(e),
+                question_number=question_number,
+                user_id=user_id
+            )
+    
+    async def _ensure_user_exists(self, user_id: str) -> User:
+        """사용자가 존재하지 않으면 생성"""
+        user = await User.find_one(User.user_id == user_id)
+        if not user:
+            user = User(
+                user_id=user_id,
+                total_conversations=Defaults.USER_CONVERSATIONS_COUNT
+            )
+            await user.save()
+            logger.info(format_message(Messages.USER_CREATED, user_id=user_id))
+        return user
+    
+    async def _find_or_create_conversation(self, user_id: str) -> Conversation:
+        """사용자의 오늘 날짜 Conversation 찾기 또는 새로 생성"""
+        today = get_korea_today()
+        
+        conversation = await Conversation.find_one(
+            Conversation.user_id == user_id,
+            Conversation.conversation_date == today
+        )
+        
+        if not conversation:
+            conversation = Conversation(
+                user_id=user_id,
+                conversation_date=today,
+                user_message=Defaults.USER_MESSAGE_EMPTY,
+                ai_sentiment=DEFAULT_AI_SENTIMENT,
+                ai_score=DEFAULT_AI_SCORE,
+                ai_comfort_message=Messages.DEFAULT_COMFORT_MESSAGE
+            )
+            await conversation.save()
+            logger.info(format_message(Messages.CONVERSATION_CREATED, user_id=user_id, date=today))
+        return conversation
+    
+    async def _save_audio_uri(self, conversation: Conversation, question_number: int, audio_uri: str):
+        """오디오 URI 저장"""
+        try:
+            audio_field = f"audio_uri_{question_number}"
+            setattr(conversation, audio_field, audio_uri)
+            await conversation.save()
+            logger.info(format_message(
+                Messages.AUDIO_URI_SAVE_SUCCESS, 
+                question_number=question_number, 
+                audio_uri=audio_uri
+            ))
+        except Exception as e:
+            logger.error(format_message(Messages.AUDIO_URI_SAVE_FAILED, error=e))
+            raise e
+    
+    async def _process_all_audio_to_text(self, conversation: Conversation):
+        """모든 오디오 파일을 STT 처리하여 통합된 텍스트로 변환"""
+        try:
+            logger.info(Messages.STT_START)
+            
+            audio_uris = self._collect_audio_uris(conversation)
+            
+            if not audio_uris:
+                logger.warning(Messages.STT_NO_FILES)
+                return
+            
+            logger.info(format_message(Messages.STT_PROCESSING, count=len(audio_uris)))
+            
+            message_parts = []
+            
+            for question_num, audio_uri in audio_uris:
+                try:
+                    question_text = self.question_service.get_question_text(question_num)
+                    transcribed_text = await self.speech_to_text_service.transcribe_audio(audio_uri)
+                    
+                    if question_text and transcribed_text:
+                        message_parts.extend([
+                            f"Q{question_num}: {question_text}",
+                            f"A{question_num}: {transcribed_text}"
+                        ])
+                    
+                    logger.info(format_message(
+                        Messages.STT_QUESTION_SUCCESS,
+                        question_num=question_num,
+                        text=transcribed_text[:Defaults.TEXT_PREVIEW_LENGTH]
+                    ))
+                    
+                except Exception as e:
+                    logger.error(format_message(Messages.STT_QUESTION_FAILED, question_num=question_num, error=e))
+                    question_text = self.question_service.get_question_text(question_num)
+                    if question_text:
+                        message_parts.extend([
+                            f"Q{question_num}: {question_text}",
+                            f"A{question_num}: 음성 변환 실패: {str(e)}"
+                        ])
+            
+            conversation.user_message = '\n'.join(message_parts)
+            
+            await self._update_user_last_active(conversation.user_id)
+            await conversation.save()
+            logger.info(Messages.STT_COMPLETE)
+            
+        except Exception as e:
+            logger.error(format_message(Messages.STT_FAILED, error=e))
+            raise e
+    
+    def _collect_audio_uris(self, conversation: Conversation) -> list[tuple[int, str]]:
+        """Conversation에서 오디오 URI들을 수집"""
+        audio_uris = []
+        for i in range(1, 4):
+            audio_uri = getattr(conversation, f"audio_uri_{i}")
+            if audio_uri:
+                audio_uris.append((i, audio_uri))
+        return audio_uris
+    
+    async def _update_user_last_active(self, user_id: str):
+        """사용자 마지막 활동 시간 업데이트"""
+        user = await User.find_one(User.user_id == user_id)
+        if user:
+            user.last_active = get_korea_now()
+            await user.save()
+
+
+answer_service = AnswerService()
+
+def get_answer_service() -> AnswerService:
+    """Answer 서비스 인스턴스 반환"""
+    return answer_service

--- a/app/services/gcp_storage.py
+++ b/app/services/gcp_storage.py
@@ -40,7 +40,10 @@ class GCPStorageService:
                 temp_file_path = temp_file.name
             
             blob = self.bucket.blob(unique_filename)
-            blob.upload_from_filename(temp_file_path)
+            blob.upload_from_filename(
+                temp_file_path,
+                content_type=audio_file.content_type
+            )
             
             os.unlink(temp_file_path)
 

--- a/app/services/gcp_storage.py
+++ b/app/services/gcp_storage.py
@@ -1,7 +1,6 @@
 import os
 import uuid
 import logging
-from typing import Optional
 from google.cloud import storage
 from fastapi import UploadFile
 import tempfile

--- a/app/services/gcp_storage.py
+++ b/app/services/gcp_storage.py
@@ -1,0 +1,72 @@
+import os
+import uuid
+import logging
+from typing import Optional
+from google.cloud import storage
+from fastapi import UploadFile
+import tempfile
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class GCPStorageService:
+    """GCP Cloud Storage 관리 서비스"""
+    
+    def __init__(self):
+        self.client = storage.Client()
+        self.bucket_name = settings.GCP_BUCKET_NAME
+        self.bucket = self.client.bucket(self.bucket_name)
+    
+    async def upload_audio_file(self, audio_file: UploadFile, user_id: str) -> str:
+        """
+        오디오 파일을 GCP Storage에 업로드
+        
+        Args:
+            audio_file: 업로드할 오디오 파일
+            user_id: 사용자 ID
+            
+        Returns:
+            str: 업로드된 파일의 GCS URI
+        """
+        try:
+            file_extension = audio_file.filename.split('.')[-1] if '.' in audio_file.filename else 'wav'
+            unique_filename = f"audio/{user_id}/{uuid.uuid4()}.{file_extension}"
+            
+            with tempfile.NamedTemporaryFile(delete=False, suffix=f".{file_extension}") as temp_file:
+                content = await audio_file.read()
+                temp_file.write(content)
+                temp_file_path = temp_file.name
+            
+            blob = self.bucket.blob(unique_filename)
+            blob.upload_from_filename(temp_file_path)
+            
+            os.unlink(temp_file_path)
+
+            gcs_uri = f"gs://{self.bucket_name}/{unique_filename}"
+            logger.info(f"✅ 오디오 파일 업로드 완료: {gcs_uri}")
+            
+            return gcs_uri
+            
+        except Exception as e:
+            logger.error(f"❌ 오디오 파일 업로드 실패: {e}")
+            if 'temp_file_path' in locals():
+                try:
+                    os.unlink(temp_file_path)
+                except:
+                    pass
+            raise e
+    
+    def get_public_url(self, gcs_uri: str) -> str:
+        """GCS URI를 공개 URL로 변환"""
+        blob_name = gcs_uri.replace(f"gs://{self.bucket_name}/", "")
+        blob = self.bucket.blob(blob_name)
+        return blob.public_url
+
+
+gcp_storage_service = GCPStorageService()
+
+def get_gcp_storage_service() -> GCPStorageService:
+    """GCP Storage 서비스 인스턴스 반환"""
+    return gcp_storage_service

--- a/app/services/question.py
+++ b/app/services/question.py
@@ -1,0 +1,32 @@
+from typing import Dict, Optional
+from app.core.constants import QUESTIONS
+
+class QuestionService:
+    """질문 관리 서비스"""
+    
+    @classmethod
+    def get_question_text(cls, question_number: int) -> Optional[str]:
+        """질문 번호로 질문 내용 조회"""
+        return QUESTIONS.get(question_number)
+    
+    @classmethod
+    def get_all_questions(cls) -> Dict[int, str]:
+        """모든 질문 목록 반환"""
+        return QUESTIONS.copy()
+    
+    @classmethod
+    def is_valid_question_number(cls, question_number: int) -> bool:
+        """유효한 질문 번호인지 확인"""
+        return question_number in QUESTIONS
+    
+    @classmethod
+    def get_total_questions(cls) -> int:
+        """전체 질문 개수 반환"""
+        return len(QUESTIONS)
+
+
+question_service = QuestionService()
+
+def get_question_service() -> QuestionService:
+    """Question 서비스 인스턴스 반환"""
+    return question_service

--- a/app/services/speech_to_text.py
+++ b/app/services/speech_to_text.py
@@ -1,0 +1,110 @@
+
+from openai import OpenAI
+import tempfile
+import os
+import hashlib
+import logging
+from google.cloud import storage
+from app.core.config import settings
+from app.core.constants import STT_MODEL, STT_LANGUAGE, STT_TEMPERATURE, ErrorMessages
+from app.utils.common import parse_gcs_uri, format_message
+
+logger = logging.getLogger(__name__)
+
+
+class SpeechToTextService:
+    """OpenAI STT를 사용한 음성-텍스트 변환 서비스"""
+
+    def __init__(self):
+        self.client = OpenAI(api_key=settings.OPENAI_API_KEY)
+        self.storage_client = storage.Client()
+        self.bucket_name = settings.GCP_BUCKET_NAME
+
+    async def transcribe_audio(self, gcs_uri: str) -> str:
+        """GCS에 저장된 오디오 파일을 텍스트로 변환"""
+        try:
+            logger.info(f"🎤 음성 변환 시작: {gcs_uri}")
+
+            bucket_name, blob_name = parse_gcs_uri(gcs_uri)
+            
+            bucket = self.storage_client.bucket(bucket_name)
+            blob = bucket.blob(blob_name)
+
+            temp_file_path = self._create_temp_file(blob_name)
+            blob.download_to_filename(temp_file_path)
+            
+            self._log_file_info(temp_file_path, gcs_uri)
+
+            try:
+                transcribed_text = self._transcribe_with_openai(temp_file_path)
+            finally:
+                self._cleanup_temp_file(temp_file_path)
+
+            logger.info(f"✅ 음성 변환 완료: {transcribed_text}")
+            return transcribed_text
+
+        except Exception as e:
+            error_message = self._handle_transcription_error(str(e))
+            logger.error(f"❌ 음성 변환 실패: {error_message}")
+            raise Exception(error_message)
+
+    def _create_temp_file(self, blob_name: str) -> str:
+        """임시 파일 생성"""
+        _, ext = os.path.splitext(blob_name)
+        if not ext:
+            ext = ".bin"
+        
+        fd, temp_file_path = tempfile.mkstemp(suffix=ext, dir="/tmp")
+        os.close(fd)
+        return temp_file_path
+
+    def _log_file_info(self, temp_file_path: str, gcs_uri: str):
+        """파일 정보 로깅"""
+        file_size = os.path.getsize(temp_file_path)
+        
+        with open(temp_file_path, "rb") as f:
+            file_hash = hashlib.md5(f.read()).hexdigest()
+        
+        logger.debug(f"📁 다운로드된 파일 정보:")
+        logger.debug(f"   - 크기: {file_size} bytes")
+        logger.debug(f"   - 해시: {file_hash}")
+        logger.debug(f"   - GCS URI: {gcs_uri}")
+
+    def _transcribe_with_openai(self, temp_file_path: str) -> str:
+        """OpenAI로 음성 변환"""
+        with open(temp_file_path, "rb") as audio_file:
+            resp = self.client.audio.transcriptions.create(
+                model=STT_MODEL,
+                file=audio_file,
+                language=STT_LANGUAGE,
+                temperature=STT_TEMPERATURE
+            )
+        return resp.text
+
+    def _cleanup_temp_file(self, temp_file_path: str):
+        """임시 파일 정리"""
+        try:
+            os.remove(temp_file_path)
+        except FileNotFoundError:
+            pass
+
+    def _handle_transcription_error(self, error_msg: str) -> str:
+        """STT 에러 처리 및 사용자 친화적 메시지 반환"""
+        lower_msg = error_msg.lower()
+        
+        if "not found" in lower_msg or "404" in lower_msg:
+            return ErrorMessages.AUDIO_FILE_NOT_FOUND
+        if "timeout" in lower_msg:
+            return ErrorMessages.STT_TIMEOUT
+        if "api key" in lower_msg or "unauthorized" in lower_msg or "invalid api key" in lower_msg:
+            return ErrorMessages.INVALID_API_KEY
+        if "no connection adapters were found" in lower_msg or "openai.audio" in lower_msg:
+            return "OpenAI SDK 사용 방식이 오래되었거나 입력 URL 형식이 잘못되었습니다."
+        
+        return format_message(ErrorMessages.STT_CONVERSION_FAILED, error=error_msg)
+
+
+speech_to_text_service = SpeechToTextService()
+
+def get_speech_to_text_service() -> SpeechToTextService:
+    return speech_to_text_service

--- a/app/services/speech_to_text.py
+++ b/app/services/speech_to_text.py
@@ -20,7 +20,7 @@ class SpeechToTextService:
         self.storage_client = storage.Client()
         self.bucket_name = settings.GCP_BUCKET_NAME
 
-    async def transcribe_audio(self, gcs_uri: str) -> str:
+    def transcribe_audio(self, gcs_uri: str) -> str:
         """GCS에 저장된 오디오 파일을 텍스트로 변환"""
         try:
             logger.info(f"🎤 음성 변환 시작: {gcs_uri}")

--- a/app/services/user.py
+++ b/app/services/user.py
@@ -1,32 +1,22 @@
 import uuid
-from datetime import datetime
-from typing import Dict, Optional
+from typing import Dict
 from fastapi import HTTPException
+
 from app.models.models import User, Conversation
 from app.schemas.requests import CompleteOnboardingRequest
-from app.schemas.common import Gender, DementiaStage, FamilyRelationship
+from app.utils.common import get_korea_now, format_message
+from app.core.constants import Messages, ErrorMessages, Defaults
+
 
 class UserService:
     """사용자 관련 서비스"""
 
     def _safe_enum_value(self, enum_value, field_name: str) -> str:
-        """
-        Enum 값을 안전하게 추출하는 헬퍼 함수
-        
-        Args:
-            enum_value: Enum 인스턴스
-            field_name: 필드명 (에러 메시지용)
-            
-        Returns:
-            str: Enum 값
-            
-        Raises:
-            HTTPException: Enum이 None이거나 잘못된 경우
-        """
+        """Enum 값을 안전하게 추출하는 헬퍼 함수"""
         if enum_value is None:
             raise HTTPException(
                 status_code=400, 
-                detail=f"데이터 검증 실패: {field_name}이(가) 설정되지 않았습니다."
+                detail=format_message(ErrorMessages.ENUM_VALIDATION_MISSING, field_name=field_name)
             )
         
         try:
@@ -34,24 +24,14 @@ class UserService:
         except AttributeError:
             raise HTTPException(
                 status_code=400, 
-                detail=f"데이터 검증 실패: {field_name}이(가) 올바른 Enum 타입이 아닙니다."
+                detail=format_message(ErrorMessages.ENUM_VALIDATION_INVALID, field_name=field_name)
             )
 
     async def create_complete_onboarding(self, onboarding_data: CompleteOnboardingRequest) -> Dict:
-        """
-        완전한 온보딩 정보 저장 (사용자 + 가족 정보)
-
-        Args:
-            onboarding_data (CompleteOnboardingRequest): 온보딩 데이터
-
-        Returns:
-            Dict: 온보딩 완료 정보
-        """
+        """완전한 온보딩 정보 저장 (사용자 + 가족 정보)"""
         try:
-            # 새로운 사용자 ID 생성
             user_id = str(uuid.uuid4())
             
-            # 사용자 정보 생성 (부양자 + 가족 정보 포함)
             user = User(
                 user_id=user_id,
                 name=onboarding_data.user_name,
@@ -59,17 +39,15 @@ class UserService:
                 gender=onboarding_data.user_gender,
                 family_relationship=onboarding_data.family_relationship,
                 daily_care_hours=onboarding_data.daily_care_hours,
-                # 부양받는 가족 정보
                 family_member_nickname=onboarding_data.family_member.nickname,
                 family_member_birth_year=onboarding_data.family_member.birth_year,
                 family_member_gender=onboarding_data.family_member.gender,
                 family_member_dementia_stage=onboarding_data.family_member.dementia_stage,
                 is_onboarded=True,
-                created_at=datetime.now(),
-                last_active=datetime.now()
+                created_at=get_korea_now(),
+                last_active=get_korea_now()
             )
             
-            # 데이터베이스에 저장
             await user.insert()
             
             return {
@@ -86,28 +64,23 @@ class UserService:
                     "dementia_stage": self._safe_enum_value(user.family_member_dementia_stage, "치매 정도")
                 },
                 "is_onboarded": user.is_onboarded,
-                "message": "온보딩이 성공적으로 완료되었습니다."
+                "message": Messages.ONBOARDING_SUCCESS
             }
         except Exception as e:
-            raise HTTPException(status_code=500, detail=f"온보딩 처리 중 오류가 발생했습니다: {str(e)}")
+            raise HTTPException(
+                status_code=500, 
+                detail=format_message(ErrorMessages.ONBOARDING_PROCESSING_ERROR, error=str(e))
+            )
 
     async def get_user_onboarding_status(self, user_id: str) -> Dict:
-        """
-        사용자 온보딩 상태 조회
-
-        Args:
-            user_id (str): 사용자 ID
-
-        Returns:
-            Dict: 사용자 온보딩 정보
-        """
+        """사용자 온보딩 상태 조회"""
         try:
             user = await User.find_one(User.user_id == user_id)
 
             if not user:
-                raise HTTPException(status_code=404, detail="사용자를 찾을 수 없습니다.")
+                raise HTTPException(status_code=404, detail=ErrorMessages.USER_NOT_FOUND)
 
-            response = {
+            return {
                 "user_id": user.user_id,
                 "user_name": user.name,
                 "user_birth_year": user.birth_year,
@@ -121,26 +94,19 @@ class UserService:
                     "dementia_stage": self._safe_enum_value(user.family_member_dementia_stage, "치매 정도")
                 },
                 "is_onboarded": user.is_onboarded,
-                "message": "온보딩 완료" if user.is_onboarded else "온보딩 미완료"
+                "message": Messages.ONBOARDING_COMPLETE if user.is_onboarded else Messages.ONBOARDING_INCOMPLETE
             }
             
-            return response
         except HTTPException:
             raise
         except Exception as e:
-            raise HTTPException(status_code=500, detail=f"온보딩 상태 조회 중 오류가 발생했습니다: {str(e)}")
+            raise HTTPException(
+                status_code=500, 
+                detail=format_message(ErrorMessages.ONBOARDING_STATUS_ERROR, error=str(e))
+            )
     
-    async def get_user_history(self, user_id: str, limit: int = 10) -> Dict:
-        """
-        사용자의 대화 기록 조회
-        
-        Args:
-            user_id (str): 사용자 ID
-            limit (int): 조회할 최대 개수
-            
-        Returns:
-            Dict: 사용자 기록
-        """
+    async def get_user_history(self, user_id: str, limit: int = Defaults.HISTORY_LIMIT) -> Dict:
+        """사용자의 대화 기록 조회 (날짜별로 구분)"""
         try:
             conversations = await Conversation.find(
                 Conversation.user_id == user_id
@@ -152,18 +118,26 @@ class UserService:
                 "conversations": [
                     {
                         "id": str(conv.id),
+                        "conversation_date": conv.conversation_date,
                         "user_message": conv.user_message,
                         "user_timestamp": conv.user_timestamp,
                         "ai_sentiment": conv.ai_sentiment,
                         "ai_score": conv.ai_score,
                         "ai_comfort_message": conv.ai_comfort_message,
-                        "ai_timestamp": conv.ai_timestamp
+                        "ai_timestamp": conv.ai_timestamp,
+                        "audio_uri_1": conv.audio_uri_1,
+                        "audio_uri_2": conv.audio_uri_2,
+                        "audio_uri_3": conv.audio_uri_3
                     }
                     for conv in conversations
                 ]
             }
         except Exception as e:
-            raise HTTPException(status_code=500, detail=f"기록 조회 중 오류가 발생했습니다: {str(e)}")
+            raise HTTPException(
+                status_code=500, 
+                detail=format_message(ErrorMessages.HISTORY_QUERY_ERROR, error=str(e))
+            )
+
 
 user_service = UserService()
 

--- a/app/utils/common.py
+++ b/app/utils/common.py
@@ -1,0 +1,71 @@
+"""공통 유틸리티 함수들"""
+
+from datetime import datetime
+from typing import Dict, Any
+from zoneinfo import ZoneInfo
+from app.core.constants import KOREA_TIMEZONE, FileFormats
+
+def get_korea_now() -> datetime:
+    """한국 시간 기준 현재 시간 반환"""
+    return datetime.now(ZoneInfo(KOREA_TIMEZONE))
+
+def get_korea_today() -> str:
+    """한국 시간 기준 오늘 날짜 반환 (YYYY-MM-DD 형식)"""
+    return get_korea_now().strftime(FileFormats.DATE_FORMAT)
+
+def format_message(template: str, **kwargs) -> str:
+    """메시지 템플릿 포맷팅"""
+    return template.format(**kwargs)
+
+def create_success_response(
+    conversation_id: str,
+    question_number: int,
+    question_text: str,
+    message: str,
+    user_id: str,
+    **additional_fields
+) -> Dict[str, Any]:
+    """공통 성공 응답 생성"""
+    response = {
+        "success": True,
+        "conversation_id": conversation_id,
+        "question_number": question_number,
+        "question_text": question_text,
+        "message": message,
+        "user_id": user_id
+    }
+    response.update(additional_fields)
+    return response
+
+def create_error_response(
+    error: str,
+    question_number: int = None,
+    user_id: str = None,
+    **additional_fields
+) -> Dict[str, Any]:
+    """공통 에러 응답 생성"""
+    response = {
+        "success": False,
+        "error": error
+    }
+    if question_number is not None:
+        response["question_number"] = question_number
+    if user_id is not None:
+        response["user_id"] = user_id
+    response.update(additional_fields)
+    return response
+
+def parse_gcs_uri(gcs_uri: str) -> tuple[str, str]:
+    """GCS URI를 bucket과 blob으로 파싱"""
+    if not gcs_uri.startswith("gs://"):
+        raise ValueError(f"잘못된 GCS URI 형식: {gcs_uri}")
+    
+    uri_body = gcs_uri[5:]
+    bucket_name, blob_name = uri_body.split("/", 1)
+    return bucket_name, blob_name
+
+def truncate_text(text: str, max_length: int) -> str:
+    """텍스트를 지정된 길이로 자르기"""
+    if len(text) <= max_length:
+        return text
+    return text[:max_length] + "..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,8 @@ dependencies = [
     "motor>=3.3.0",
     "pymongo>=4.6.0",
     "beanie>=1.25.0",
+    "openai>=1.0.0",
+    "requests>=2.31.0",
+    "google-cloud-storage>=2.10.0",
+    "python-multipart>=0.0.20",
 ]


### PR DESCRIPTION
<!--
name: MoA Project Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #11

## Work Description ✏️
### 🎯 주요 기능
- 오디오 파일 GCP Cloud Storage 에 업로드
- OpenAI Whisper API로 STT 처리 
- 3번째 오디오까지 업로드 완료 되었을 때 OpenAI API 호출하도록 처리
- 텍스트로 변환된 데이터 DB에 저장

### 🏗️ 아키텍처 개선
- `constants.py`를 통한 하드코딩 제거
-  한국 시간 처리, 메시지 포맷팅 등 재사용 가능한 함수

### 🔧 기술 스택 추가
- `openai`: Whisper STT API 연동
- `google-cloud-storage`: GCP 스토리지 연동  
- `python-multipart`: 멀티파트 파일 업로드 지원

### 엔드포인트
- `GET /api/answer/questions`: 전체 질문 목록 조회
- `GET /api/answer/questions/{question_number}`: 특정 질문 조회  
- `POST /api/answer/audio`: 오디오 파일 업로드 및 처리

### 응답 예시
<img width="2802" height="730" alt="image" src="https://github.com/user-attachments/assets/d883b5cb-cbbf-4674-9b92-c1ded3938737" />

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 3번째 음성 파일 전달 받을 때 Text로 변환 & 데일리 리포트 생성 하도록 구현하면 좋을 거 같습니당!! 응답까진 얼마나 걸릴지 테스트해봐야할 거 같아요
- 음성 파일 현재는 10MB로 제한두었는데, 테스트후에 적절하게 변경하면 좋을 것 같습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 오디오 답변 업로드/저장 및 전사 처리 기능과 관련 API(질문 목록/개별 조회 포함)가 추가되었습니다.
* **버그 수정**
  * 사용자 및 대화 타임스탬프가 한국 표준시로 일관되게 처리됩니다.
* **개선 및 변경**
  * 대화 기록에 오디오 URI와 대화 날짜가 포함되어 기록 범위가 확장되었습니다.
  * 시스템·에러 메시지와 기본값이 중앙화되어 일관성 향상되었습니다.
  * OpenAI/GCP 연동 설정 및 관련 외부 의존성이 추가되었습니다.
* **문서화**
  * API 응답 구조가 확장되어 한글화 및 명확화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->