### PR TITLE
[FEAT/#18] 레포트 리스트 조회 로직 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ uv.lock
 
 # env
 .env
+
+# json
+*.json

--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -9,6 +9,6 @@ router = APIRouter(prefix="/reports", tags=["reports"])
 async def list_reports(
     limit: int = Defaults.HISTORY_LIMIT,
     user_id: str = Header(..., alias="X-User-Id"),
-    report_service: ReportService = Depends(get_report_service())
+    report_service: ReportService = Depends(get_report_service)
 ):
     return await report_service.get_user_reports(user_id, limit)

--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -1,5 +1,4 @@
-from fastapi import APIRouter, Depends, Header
-from app.core.constants import Defaults
+from fastapi import APIRouter, Depends, Header, Query
 from app.services.report import ReportService, get_report_service
 from app.schemas.responses import ReportsListResponse
 
@@ -7,8 +6,13 @@ router = APIRouter(prefix="/reports", tags=["reports"])
 
 @router.get("/", response_model=ReportsListResponse)
 async def list_reports(
-    limit: int = Defaults.HISTORY_LIMIT,
+    year: int = Query(..., description="조회할 연도 (예: 2025)"),
+    month: int = Query(..., ge=1, le=12, description="조회할 월 (1~12)"),
     x_user_id: str = Header(..., alias="X-User-Id"),
     report_service: ReportService = Depends(get_report_service)
 ):
-    return await report_service.get_user_reports(x_user_id, limit)
+    return await report_service.get_user_reports(
+        user_id=x_user_id,
+        year=year,
+        month=month
+    )

--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, Depends, Header
+from app.core.constants import Defaults
+from app.services.user import get_user_service, UserService
+from app.schemas.responses import ReportsListResponse
+
+router = APIRouter(prefix="/reports", tags=["reports"])
+
+@router.get("/", response_model=ReportsListResponse)
+async def list_reports(
+    limit: int = Defaults.HISTORY_LIMIT,
+    user_id: str = Header(..., alias="X-User-Id"),
+    user_service: UserService = Depends(get_user_service)
+):
+    return await user_service.get_user_history(user_id, limit)

--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, Header
 from app.core.constants import Defaults
-from app.services.user import get_user_service, UserService
+from app.services.report import ReportService, get_report_service
 from app.schemas.responses import ReportsListResponse
 
 router = APIRouter(prefix="/reports", tags=["reports"])
@@ -9,6 +9,6 @@ router = APIRouter(prefix="/reports", tags=["reports"])
 async def list_reports(
     limit: int = Defaults.HISTORY_LIMIT,
     user_id: str = Header(..., alias="X-User-Id"),
-    user_service: UserService = Depends(get_user_service)
+    report_service: ReportService = Depends(get_report_service())
 ):
-    return await user_service.get_user_history(user_id, limit)
+    return await report_service.get_user_reports(user_id, limit)

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -15,7 +15,7 @@ async def create_onboarding(
     """
     return await user_service.create_complete_onboarding(onboarding_data)
 
-@router.get("/{user_id}/onboarding")
+@router.get("/onboarding")
 async def get_onboarding_status(
     x_user_id: str = Header(..., alias="X-User-Id"),
     user_service: UserService = Depends(get_user_service)

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -1,8 +1,7 @@
 from fastapi import APIRouter, Depends, status
-from app.core.constants import Defaults
 from app.services.user import get_user_service, UserService
 from app.schemas.requests import CompleteOnboardingRequest
-from app.schemas.responses import OnboardingResponse, UserHistoryResponse
+from app.schemas.responses import OnboardingResponse
 
 router = APIRouter(prefix="/api/users", tags=["users"])
 
@@ -25,14 +24,3 @@ async def get_onboarding_status(
     사용자 온보딩 상태 조회
     """
     return await user_service.get_user_onboarding_status(user_id)
-
-@router.get("/{user_id}/history", response_model=UserHistoryResponse)
-async def get_user_history(
-    user_id: str,
-    limit: int = Defaults.HISTORY_LIMIT,
-    user_service: UserService = Depends(get_user_service)
-):
-    """
-    사용자 대화 기록 조회
-    """
-    return await user_service.get_user_history(user_id, limit)

--- a/app/core/constants.py
+++ b/app/core/constants.py
@@ -26,6 +26,7 @@ ALLOWED_AUDIO_TYPES = [
     "audio/aac",
     "audio/flac",
     "audio/3gpp",
+    "video/webm"
 ]
 
 # AI 관련 상수

--- a/app/main.py
+++ b/app/main.py
@@ -4,8 +4,7 @@ from contextlib import asynccontextmanager
 
 from app.core.config import settings
 from app.core.database import connect_to_mongo, close_mongo_connection
-from app.api import users
-from app.api import answers
+from app.api import users, reports, answers
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -32,6 +31,7 @@ def create_app() -> FastAPI:
     )
 
     app.include_router(users.router, prefix="/api")
+    app.include_router(reports.router, prefix="/api")
     app.include_router(answers.router, prefix="/api")
 
     @app.get("/")

--- a/app/main.py
+++ b/app/main.py
@@ -7,8 +7,6 @@ from app.core.database import connect_to_mongo, close_mongo_connection
 from app.api import users
 from app.api import answers
 
-import app.core.logger
-
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """애플리케이션 라이프사이클 관리"""

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -36,7 +36,7 @@ class Conversation(Document):
 
 class ConversationSummary(BaseModel):
     id: PydanticObjectId = Field(alias="_id")      # Mongo _id
-    conversation_date: datetime = Field(alias="conversation_date")
+    conversation_date: str = Field(alias="conversation_date")
 
 class User(Document):
     """사용자 정보 모델 (부양자 + 부양받는 가족 정보 포함)"""

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -37,8 +37,8 @@ class Conversation(Document):
         ]
 
 class ConversationSummary(BaseModel):
-    id: PydanticObjectId          # Mongo _id
-    conversation_date: str
+    id: PydanticObjectId = Field(alias="_id")      # Mongo _id
+    conversation_date: datetime = Field(alias="user_timestamp")
 
 class User(Document):
     """사용자 정보 모델 (부양자 + 부양받는 가족 정보 포함)"""

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -1,7 +1,5 @@
 from datetime import datetime
 from typing import Optional
-from beanie import Document
-from pydantic import Field
 from pymongo import ASCENDING
 from app.schemas.common import Gender, DementiaStage, FamilyRelationship
 from app.schemas.reports import ConversationReport

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -36,7 +36,7 @@ class Conversation(Document):
 
 class ConversationSummary(BaseModel):
     id: PydanticObjectId = Field(alias="_id")      # Mongo _id
-    conversation_date: datetime = Field(alias="user_timestamp")
+    conversation_date: datetime = Field(alias="conversation_date")
 
 class User(Document):
     """사용자 정보 모델 (부양자 + 부양받는 가족 정보 포함)"""

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -7,6 +7,8 @@ from app.schemas.common import Gender, DementiaStage, FamilyRelationship
 from app.schemas.reports import ConversationReport
 from app.utils.common import get_korea_now
 from app.core.constants import Defaults
+from beanie import Document, PydanticObjectId
+from pydantic import BaseModel, Field
 
 
 class Conversation(Document):
@@ -33,6 +35,10 @@ class Conversation(Document):
         indexes = [
             [("user_id", ASCENDING), ("conversation_date", ASCENDING)]
         ]
+
+class ConversationSummary(BaseModel):
+    id: PydanticObjectId          # Mongo _id
+    conversation_date: str
 
 class User(Document):
     """사용자 정보 모델 (부양자 + 부양받는 가족 정보 포함)"""

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -4,7 +4,7 @@ API 스키마 패키지
 
 from .requests import CompleteOnboardingRequest, FamilyMemberInfo, MessageRequest, WebSocketMessage
 from .responses import (
-    OnboardingResponse, ConversationItem, UserHistoryResponse, 
+    OnboardingResponse, ConversationItem, ReportsHistoryResponse,
     FamilyMemberResponse, AudioAnswerResponse, AnalysisResponse
 )
 from .common import Gender, DementiaStage, FamilyRelationship
@@ -12,7 +12,7 @@ from .reports import ConversationReport, ConversationReportEmotion
 
 __all__ = [
     "CompleteOnboardingRequest", "FamilyMemberInfo", "MessageRequest", "WebSocketMessage",
-    "OnboardingResponse", "ConversationItem", "UserHistoryResponse", 
+    "OnboardingResponse", "ConversationItem", "ReportsHistoryResponse",
     "FamilyMemberResponse", "AudioAnswerResponse", "AnalysisResponse",
     "Gender", "DementiaStage", "FamilyRelationship",
     "ConversationReport", "ConversationReportEmotion"

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -4,7 +4,7 @@ API 스키마 패키지
 
 from .requests import CompleteOnboardingRequest, FamilyMemberInfo, MessageRequest, WebSocketMessage
 from .responses import (
-    OnboardingResponse, ConversationItem, ReportsHistoryResponse,
+    OnboardingResponse, ConversationItem, ReportsListResponse,
     FamilyMemberResponse, AudioAnswerResponse, AnalysisResponse
 )
 from .common import Gender, DementiaStage, FamilyRelationship
@@ -12,7 +12,7 @@ from .reports import ConversationReport, ConversationReportEmotion
 
 __all__ = [
     "CompleteOnboardingRequest", "FamilyMemberInfo", "MessageRequest", "WebSocketMessage",
-    "OnboardingResponse", "ConversationItem", "ReportsHistoryResponse",
+    "OnboardingResponse", "ConversationItem", "ReportsListResponse",
     "FamilyMemberResponse", "AudioAnswerResponse", "AnalysisResponse",
     "Gender", "DementiaStage", "FamilyRelationship",
     "ConversationReport", "ConversationReportEmotion"

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from pydantic import BaseModel, Field
-from typing import Optional
 from .common import Gender, DementiaStage, FamilyRelationship
 
 class FamilyMemberInfo(BaseModel):

--- a/app/schemas/responses.py
+++ b/app/schemas/responses.py
@@ -65,8 +65,8 @@ class ConversationItem(BaseModel):
 
 class ReportSummaryResponse(BaseModel):
     """리포트 간략 조회 응답"""
-    conversation_id: str
-    conversation_date: datetime  # 또는 str
+    report_id: str
+    report_date: datetime  # 또는 str
 
 class ReportsListResponse(BaseModel):
     """리포트 목록 응답"""

--- a/app/schemas/responses.py
+++ b/app/schemas/responses.py
@@ -66,7 +66,7 @@ class ConversationItem(BaseModel):
 class ReportSummaryResponse(BaseModel):
     """리포트 간략 조회 응답"""
     report_id: str
-    report_date: datetime  # 또는 str
+    report_date: str
 
 class ReportsListResponse(BaseModel):
     """리포트 목록 응답"""

--- a/app/schemas/responses.py
+++ b/app/schemas/responses.py
@@ -63,8 +63,13 @@ class ConversationItem(BaseModel):
     audio_uri_3: Optional[str] = None
     report: Optional[ConversationReport] = None
 
-class UserHistoryResponse(BaseModel):
-    """사용자 기록 응답"""
+class ReportSummaryResponse(BaseModel):
+    """리포트 간략 조회 응답"""
+    conversation_id: str
+    conversation_date: datetime  # 또는 str
+
+class ReportsListResponse(BaseModel):
+    """리포트 목록 응답"""
     user_id: str
     total_count: int
-    conversations: List[ConversationItem]
+    reports: List[ReportSummaryResponse]

--- a/app/schemas/responses.py
+++ b/app/schemas/responses.py
@@ -70,6 +70,5 @@ class ReportSummaryResponse(BaseModel):
 
 class ReportsListResponse(BaseModel):
     """리포트 목록 응답"""
-    user_id: str
     total_count: int
     reports: List[ReportSummaryResponse]

--- a/app/services/report.py
+++ b/app/services/report.py
@@ -81,7 +81,10 @@ class ReportService:
             )
 
             summaries = [
-                {"conversation_id": str(r.id), "conversation_date": r.conversation_date}
+                {
+                    "conversation_id": str(r.id),
+                    "conversation_date": r.conversation_date,
+                }
                 for r in rows
             ]
 

--- a/app/services/report.py
+++ b/app/services/report.py
@@ -105,7 +105,6 @@ class ReportService:
             ]
 
             return {
-                "user_id": user_id,
                 "total_count": len(rows),
                 "reports": summaries,
             }

--- a/app/services/report.py
+++ b/app/services/report.py
@@ -82,8 +82,8 @@ class ReportService:
 
             summaries = [
                 {
-                    "conversation_id": str(r.id),
-                    "conversation_date": r.conversation_date,
+                    "report_id": str(r.id),
+                    "report_date": r.conversation_date,
                 }
                 for r in rows
             ]

--- a/app/services/report.py
+++ b/app/services/report.py
@@ -83,7 +83,7 @@ class ReportService:
             summaries = [
                 {
                     "report_id": str(r.id),
-                    "report_date": r.conversation_date,
+                    "report_date": r.conversation_date.strftime("%Y년 %-m월 %-d일"),
                 }
                 for r in rows
             ]

--- a/app/services/report.py
+++ b/app/services/report.py
@@ -1,5 +1,7 @@
 import uuid
 from datetime import datetime
+from zoneinfo import ZoneInfo
+from app.core.constants import KOREA_TIMEZONE
 from fastapi import HTTPException
 from typing import Dict, Optional
 import logging
@@ -77,11 +79,12 @@ class ReportService:
             month: int
     ) -> dict:
         try:
-            start = datetime(year, month, 1)
+            tz = ZoneInfo(KOREA_TIMEZONE)
+            start = datetime(year, month, 1, tzinfo=tz)
             if month == 12:
-                end = datetime(year + 1, 1, 1)
+                end = datetime(year + 1, 1, 1, tzinfo=tz)
             else:
-                end = datetime(year, month + 1, 1)
+                end = datetime(year, month + 1, 1, tzinfo=tz)
 
             query = {
                 "user_id": user_id,

--- a/app/services/user.py
+++ b/app/services/user.py
@@ -131,48 +131,7 @@ class UserService:
                 status_code=500, 
                 detail=format_message(ErrorMessages.ONBOARDING_STATUS_ERROR, error=str(e))
             )
-    
-    async def get_user_history(self, user_id: str, limit: int = Defaults.HISTORY_LIMIT) -> Dict:
-        """
-        사용자의 대화 기록 조회
-        
-        Args:
-            user_id (str): 사용자 ID
-            limit (int): 조회할 최대 개수
-            
-        Returns:
-            Dict: 사용자 기록
-        """
-        try:
-            conversations = await Conversation.find(
-                Conversation.user_id == user_id
-            ).sort(-Conversation.user_timestamp).limit(limit).to_list()
-            
-            return {
-                "user_id": user_id,
-                "total_count": len(conversations),
-                "conversations": [
-                    {
-                        "id": str(conv.id),
-                         "conversation_date": conv.conversation_date,
-                        "user_message": conv.user_message,
-                        "user_timestamp": conv.user_timestamp,
-                        "ai_sentiment": conv.ai_sentiment,
-                        "ai_score": conv.ai_score,
-                        "ai_comfort_message": conv.ai_comfort_message,
-                        "ai_timestamp": conv.ai_timestamp,
-                        "audio_uri_1": conv.audio_uri_1,
-                        "audio_uri_2": conv.audio_uri_2,
-                        "audio_uri_3": conv.audio_uri_3
-                    }
-                    for conv in conversations
-                ]
-            }
-        except Exception as e:
-            raise HTTPException(
-                status_code=500, 
-                detail=format_message(ErrorMessages.HISTORY_QUERY_ERROR, error=str(e))
-            )
+
 user_service = UserService()
 
 def get_user_service() -> UserService:


### PR DESCRIPTION
<!--
name: MoA Project Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #18

## Work Description ✏️
- reports 관련 클래스 분리(api)
- 년도 및 월을 바탕으로 조회할 수 있는 레포트 필터링 기능 추가
- projection을 통해 리포트 id 및 날짜만 반환되도록 변경

<img width="940" height="786" alt="스크린샷 2025-08-15 오전 2 06 23" src="https://github.com/user-attachments/assets/42fe285a-20bd-4d0a-a2ed-e74feeca6a6f" />


## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 월별 리포트 조회 API 추가: GET /api/reports?year=&month= (X-User-Id 필요). 응답에 total_count 및 reports[{report_id, report_date}] 제공.

- **Refactor**
  - 사용자 히스토리 조회 엔드포인트 및 관련 응답 타입 제거; 온보딩 경로 유지.  
  - 리포트 요약 모델 도입 및 공용 응답 구조 간소화.  
  - 리포트 서비스 및 라우팅 통합, 사용자 서비스에 단일 인스턴스 접근자 추가.

- **Chores**
  - .gitignore에 *.json 규칙 추가.  
  - 허용 오디오 타입에 video/webm 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->