### PR TITLE
[FEAT/#15] 레포트 상세조회 API 구현

### DIFF
--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, Header, Query
 from app.services.report import ReportService, get_report_service
-from app.schemas.responses import ReportsListResponse
+from app.schemas.responses import ReportsListResponse, ReportDetailResponse
 
 router = APIRouter(prefix="/reports", tags=["reports"])
 
@@ -16,3 +16,11 @@ async def list_reports(
         year=year,
         month=month
     )
+
+@router.get("/{report_id}", response_model=ReportDetailResponse)
+async def get_report_detail(
+    report_id: str,
+    x_user_id: str = Header(..., alias="X-User-Id"),
+    report_service: ReportService = Depends(get_report_service),
+):
+    return await report_service.get_report_detail(user_id=x_user_id, report_id=report_id)

--- a/app/schemas/responses.py
+++ b/app/schemas/responses.py
@@ -1,8 +1,11 @@
+from dataclasses import Field
+
 from pydantic import BaseModel
 from datetime import datetime
 from typing import List, Optional
 
-from app.schemas.reports import ConversationReport
+from app.schemas.reports import ConversationReport, ConversationReportEmotion
+
 
 class FamilyMemberResponse(BaseModel):
     """가족 구성원 응답"""
@@ -72,3 +75,12 @@ class ReportsListResponse(BaseModel):
     """리포트 목록 응답"""
     total_count: int
     reports: List[ReportSummaryResponse]
+
+class ReportDetailResponse(BaseModel):
+    """리포트 상세보기 응답"""
+    report_id: str
+    report_date: str
+    emotion_score: int
+    daily_summary: str
+    emotion_analysis: ConversationReportEmotion
+    letter: str


### PR DESCRIPTION
<!--
name: MoA Project Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #15

## Work Description ✏️
- 레포트 상세조회 API 구현

<img width="1047" height="257" alt="image" src="https://github.com/user-attachments/assets/b820c0e5-3258-4899-9396-11f921245b7b" />


## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 단일 리포트 상세 조회 API(GET /reports/{report_id})가 추가되었습니다. 요청 시 헤더 X-User-Id가 필요합니다.
  - 응답에는 리포트 ID, 리포트 날짜, 감정 점수, 일일 요약, 감정 분석, 편지 내용이 포함되어 상세 정보를 한 번에 확인할 수 있습니다. 준비되지 않았거나 존재하지 않는 리포트는 조회할 수 없습니다.
  - 기존 리포트 목록 API의 동작과 응답 형식은 변경되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->