### PR TITLE
[FIX/#23] conversation date 저장 타입 변경과 프론트 오류 수정

### DIFF
--- a/app/api/users.py
+++ b/app/api/users.py
@@ -3,7 +3,7 @@ from app.services.user import get_user_service, UserService
 from app.schemas.requests import CompleteOnboardingRequest
 from app.schemas.responses import OnboardingResponse
 
-router = APIRouter(prefix="/api/users", tags=["users"])
+router = APIRouter(prefix="/users", tags=["users"])
 
 @router.post("/onboarding", response_model=OnboardingResponse, status_code=status.HTTP_201_CREATED)
 async def create_onboarding(

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -25,10 +25,9 @@ class Settings:
     GOOGLE_APPLICATION_CREDENTIALS: str = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")
 
     ALLOWED_ORIGINS: list = [
-        "http://localhost:3000",
-        "http://localhost:3001", 
-        "http://127.0.0.1:3000",
-        "http://127.0.0.1:3001",
+        "http://localhost:8080",
+        "http://127.0.0.1:8080",
+        "https://moa-platform.vercel.app"
     ]
     
     class Config:

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -1,9 +1,9 @@
-from datetime import datetime
+from datetime import datetime, date
 from typing import Optional
 from pymongo import ASCENDING
 from app.schemas.common import Gender, DementiaStage, FamilyRelationship
 from app.schemas.reports import ConversationReport
-from app.utils.common import get_korea_now
+from app.utils.common import get_korea_now, get_korea_today_date
 from app.core.constants import Defaults
 from beanie import Document, PydanticObjectId
 from pydantic import BaseModel, Field
@@ -12,7 +12,7 @@ from pydantic import BaseModel, Field
 class Conversation(Document):
     """대화 기록 모델 - 사용자 메시지와 AI 응답을 하나로 관리"""
     user_id: str
-    conversation_date: datetime = Field(default_factory=get_korea_now)
+    conversation_date: date = Field(default_factory=get_korea_today_date)
     is_processed: bool = Defaults.CONVERSATION_PROCESSED_STATUS
     
     user_message: str
@@ -36,7 +36,7 @@ class Conversation(Document):
 
 class ConversationSummary(BaseModel):
     id: PydanticObjectId = Field(alias="_id")      # Mongo _id
-    conversation_date: datetime
+    conversation_date: date
 
 class User(Document):
     """사용자 정보 모델 (부양자 + 부양받는 가족 정보 포함)"""

--- a/app/schemas/responses.py
+++ b/app/schemas/responses.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from datetime import datetime
+from datetime import datetime, date
 from typing import List, Optional
 
 from app.schemas.reports import ConversationReport, ConversationReportEmotion
@@ -52,7 +52,7 @@ class AudioAnswerResponse(BaseModel):
 class ConversationItem(BaseModel):
     """대화 기록 아이템"""
     id: str
-    conversation_date: str
+    conversation_date: date
     user_message: str
     user_timestamp: datetime
     ai_sentiment: str

--- a/app/utils/common.py
+++ b/app/utils/common.py
@@ -1,7 +1,7 @@
 """공통 유틸리티 함수들"""
 
-from datetime import datetime
-from typing import Dict, Any
+from datetime import datetime, date
+from typing import Dict, Any, Union
 from zoneinfo import ZoneInfo
 from app.core.constants import KOREA_TIMEZONE, FileFormats
 
@@ -13,30 +13,34 @@ def get_korea_today() -> str:
     """한국 시간 기준 오늘 날짜 반환 (YYYY-MM-DD 형식)"""
     return get_korea_now().strftime(FileFormats.DATE_FORMAT)
 
+def get_korea_today_date() -> date:
+    """한국 시간 기준 오늘 날짜 반환 (date 타입)"""
+    return get_korea_now().date()
 
-def format_date_for_display(date: datetime) -> str:
+
+def format_date_for_display(date_obj: Union[datetime, date]) -> str:
     """
     날짜를 한국어 표시 형식으로 변환합니다.
     크로스 플랫폼 호환성을 위해 strftime의 플랫폼별 차이를 해결합니다.
     """
-    if not date:
+    if not date_obj:
         return ""
 
     # 월과 일에서 앞의 0을 제거
-    month = str(date.month).lstrip('0') or '1'
-    day = str(date.day).lstrip('0') or '1'
+    month = str(date_obj.month).lstrip('0') or '1'
+    day = str(date_obj.day).lstrip('0') or '1'
 
     return f"{month}월 {day}일"
 
 
-def format_date_for_database(date: datetime) -> str:
+def format_date_for_database(date_obj: Union[datetime, date]) -> str:
     """
     날짜를 데이터베이스 저장용 문자열 형식으로 변환합니다.
     """
-    if not date:
+    if not date_obj:
         return ""
 
-    return date.strftime("%Y-%m-%d")
+    return date_obj.strftime("%Y-%m-%d")
 
 def format_message(template: str, **kwargs) -> str:
     """메시지 템플릿 포맷팅"""


### PR DESCRIPTION
<!--
name: MoA Project Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #23

## Work Description ✏️
- conversation date 저장 타입을 str -> date로 변경했어요
- endpoint 에 api가 중복되어 들어가있던 오류도 수정했어요
- origin 추가했어요 (cors오류 해결)

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 프런트엔드 접근 허용 범위 확장: 프로덕션 도메인 및 localhost:8080 지원(CORS).
  - 대화 날짜가 날짜 단위(YYYY-MM-DD)로 일관되게 제공되어 표시/정렬 안정성 향상.

- Refactor
  - 사용자 API 기본 경로가 /api/users에서 /users로 변경됨. 클라이언트 요청 경로 업데이트 필요(호환성 주의).

- Chores
  - 날짜/시간 유틸리티의 입력 형식 유연성 향상으로 표시·저장 포맷 처리 일관화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->