### PR TITLE
[FIX] get reports endpoint 뒤에 '/' 제거

### DIFF
--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -4,7 +4,7 @@ from app.schemas.responses import ReportsListResponse, ReportDetailResponse
 
 router = APIRouter(prefix="/reports", tags=["reports"])
 
-@router.get("/", response_model=ReportsListResponse)
+@router.get("", response_model=ReportsListResponse)
 async def list_reports(
     year: int = Query(..., description="조회할 연도 (예: 2025)"),
     month: int = Query(..., ge=1, le=12, description="조회할 월 (1~12)"),


### PR DESCRIPTION
<!--
name: MoA Project Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #27 

## Work Description ✏️
- get reports endpoint 뒤에 '/' 제거

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능

- 버그 수정

- 문서

- 리팩터링
  - 보고서 목록 API 엔드포인트를 "/reports/"에서 "/reports"로 변경하여 후행 슬래시를 제거했습니다.
  - 북마크, 통합, 클라이언트 요청 URL에서 후행 슬래시를 사용 중인 경우 응답 실패가 발생할 수 있으니 "/reports"로 업데이트하세요.
  - 자동 리다이렉트는 제공되지 않습니다. 캐시/프록시 규칙과 모니터링 알림도 새 경로에 맞게 수정하는 것을 권장합니다.

- 스타일

- 테스트

- 작업

- 되돌리기

<!-- end of auto-generated comment: release notes by coderabbit.ai -->